### PR TITLE
Adds better handling for multi-value query parameters, fixes a case-sensitivity bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 A PostHog app to convert specific url search/query parameters to event properties allowing you to more easily compare them in insights.
 
-By default, this converts no parameter at all. By white listing parameters the app will look for those and convert to properties
+You can specify a list of parameters to convert. Converted parameters are stored as event properties, but you can configure the plugin to set them as (initial) user properties as well. Properties are created using the parameter name and an optional prefix and suffix. (Initial user properties also get `initial_` prepended to the property name.)
+
+If a configured parameter is found one time, it will store the data as-is. If the parameter is found more than once, it will gather all the values found into an array, and store that in the property in JSON format. Or, you can set it to always store the data as a JSON array.
 
 Support [PostHog](https://posthog.com/) and give it a try today.
 

--- a/plugin.json
+++ b/plugin.json
@@ -48,6 +48,14 @@
             "choices": ["true", "false"],
             "default": "false",
             "hint": "Additionally adds the property to the user initial properties. This will add a prefix of 'initial_' before the already fully composed property e.g. initial_prefix_followerId_suffix"
+        },
+        {
+            "key": "alwaysJson",
+            "name": "Always JSON stringify the property data",
+            "type": "choice",
+            "choices": ["true", "false"],
+            "default": "false",
+            "hint": "If set, always store the resulting data as a JSON array. (Otherwise, single parameters get stored as-is, and multi-value parameters get stored as a JSON array.)"
         }
     ]
 }


### PR DESCRIPTION

## Changes

- If parameters in the query string appeared more than once, the app would get the first and then stop. Now, it should retrieve all of the values for the parameter, and store them appropriately.
   - If there's a single item, by default pop it out of the resulting array and store as a string (for backwards compatibility).
   - If there's more than one, JSONify the resulting array and store that instead.
   - You can opt to always store a JSON array if you want, too.
- The logic for case insensitivity was not great - it checked URLSearchParams for a toLowerCase'd configured property name, but URLSearchParams's get/getAll are case sensitive. So, instead it now loops over the keys and lowercases both the key and the param name for comparison.
- Updated the documentation accordingly.

## Checklist

- [ ] Automated tests pass
